### PR TITLE
Only use `macos-latest` for CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         version: [10.15, 10.14, 10.13]
       fail-fast: false
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.version }}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         version: [10.15, 10.14, 10.13]
       fail-fast: false
-    runs-on: ${{ matrix.version }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        version: [10.15, 10.14, 10.13]
-      fail-fast: false
+        os: [macOS-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
My bad - github actions only supports `macos-latest` for CI.