### PR TITLE
deluge: add service block

### DIFF
--- a/Formula/deluge-meta.rb
+++ b/Formula/deluge-meta.rb
@@ -143,13 +143,21 @@ class DelugeMeta < Formula
   end
 
   def install
-    virtualenv_install_with_resources
+    virtualenv_install_with_resources using: "python@3.11"
 
     %w[deluge deluge-console deluge-gtk deluge-web deluged].each do |cmd|
       (bin/cmd).write_env_script(libexec/"bin/#{cmd}", PYTHONPATH: ENV["PYTHONPATH"])
     end
 
     man1.install Dir["docs/man/*.1"]
+
+    (var/"log/deluge-meta").mkpath
+  end
+
+  service do
+    run [opt_bin/"deluged", "--do-not-daemonize", "--loglevel", "info", "--logfile",
+         var/"log/deluge-meta/deluged.log"]
+    keep_alive true
   end
 
   test do

--- a/Formula/deluge-meta.rb
+++ b/Formula/deluge-meta.rb
@@ -6,7 +6,7 @@ class DelugeMeta < Formula
   url "https://files.pythonhosted.org/packages/00/d7/8673068046ded6eaa82caaa2afd6f0751faf591aab5ad150aeafe0d47cb3/deluge-2.1.1.tar.gz"
   sha256 "d6ea7e1f5bdd75f40cbd1d56f0c97cd1b5b74bc9e03783858c7daa81063dd4b9"
   license "GPL-3.0"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://github.com/Amar1729/homebrew-deluge-meta/releases/download/deluge-meta-2.1.1_1"


### PR DESCRIPTION
Closes #18 

Thanks to @grigarr for writing up a plist file for deluge. I almost committed it, but looks like Homebrew has switched over to using [`service do` blocks](https://docs.brew.sh/Formula-Cookbook#service-files) instead of manually writing out plist files, making for cleaner formulae files.

This should work for allowing deluge to run as a service.

sidenote: i might try to also write a service that can start `deluge-web`?