### PR TITLE
ci: update with env vars from updated Homebrew actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,16 @@
 name: brew test-bot
+
 on:
   push:
     branches: main
   pull_request:
+
+env:
+  HOMEBREW_DEVELOPER: 1
+  HOMEBREW_GITHUB_ACTIONS: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_INSTALL_FROM_API: 1
+
 jobs:
   test-bot:
     strategy:


### PR DESCRIPTION
Without this, CI is resulting in errors:
```
==> brew test --verbose amar1729/deluge-meta/deluge-meta
==> FAILED
Full test amar1729/deluge-meta/deluge-meta output
  Error: test failed
  Error: amar1729/deluge-meta/deluge-meta is missing test dependencies: python@3.11
Truncated test amar1729/deluge-meta/deluge-meta output
  Error: Error: amar1729/deluge-meta/deluge-meta is missing test dependencies: python@3.11
  
```

- https://github.com/Homebrew/homebrew-core/commit/c9ccd8e7af8600238fce034c5a8d832b25e39b51
- https://github.com/Homebrew/discussions/discussions/4150